### PR TITLE
Added GTM

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,10 +1,19 @@
 import "../styles/global.css";
 import Head from 'next/head';
-
+import Script from 'next/script';
 function MyApp({ Component, pageProps }) {
   return (
 		<div>
 			<Head>
+
+				{/* Google Tag Manager */}
+				<script dangerouslySetInnerHTML={{ __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+				new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+				j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+				'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+				})(window,document,'script','dataLayer','GTM-XXXXXXX');`}}></script>
+				{/* Google Tag Manager */}
+
 				<meta name='description' content='4C: The Cool Community for Content Creators' />
 			</Head>
 			<Component {...pageProps} />;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -6,6 +6,12 @@ class MyDocument extends Document {
 			<Html lang='en'>
 			<Head />
 				<body>
+
+					{/* Google Tag Manager */}
+					<noscript dangerouslySetInnerHTML={{ __html: `<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXXXXX"
+					height="0" width="0" style="display:none;visibility:hidden"></iframe>`}}></noscript>
+					{/* Google Tag Manager */}
+
 					<Main />
 					<NextScript />
 				</body>

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,8 @@ import Head from "next/head";
 import Navbar from "../components/Navbar";
 import About from "../components/About";
 import Join from "../components/Join";
+
+
 export default function Home() {
   return (
     <div className="flex flex-col min-h-screen">


### PR DESCRIPTION

I Added Google Tag Manager to the website, so you can track your site traffic.

GTM allows to get to know your traffic very well and I've used it on many projects of my own.



In order for the gtm scripts to work, we just need to replace the example  `GTM-XXXXXXX` id with your own id.
There are two places where we should set the GTM id
*  `pages/_document.js` at line 11
*  `pages/_app.js` at line 14

I don't know if this is something you were planning on adding later, so I made my fork.

Let me know if this is something you think is relevant.

