### PR TITLE
fix: text overlap with nav area

### DIFF
--- a/components/Hero.js
+++ b/components/Hero.js
@@ -2,7 +2,7 @@ import Image from "next/image";
 
 const Hero = ({ eyebrow, title, description, primaryLink, secondaryLink }) => {
   return (
-    <section className="container">
+    <section className="container mt-16">
       <div className="items-center grid md:grid-cols-3 lg:grid-cols-2 gap-12">
         <div className="col-span-2 lg:col-span-1">
           <p className="text-sm font-bold tracking-wide text-orange-600 uppercase">


### PR DESCRIPTION
In this PR, I have taken care of #42. 

**Before**

<img width="411" alt="image" src="https://user-images.githubusercontent.com/44341551/134401944-6dcc8835-952c-47de-8d74-85a7fa4af243.png">

**After**

<img width="410" alt="image" src="https://user-images.githubusercontent.com/44341551/134402009-fd5e76d3-98a9-4862-b063-20576485b223.png">
