### PR TITLE
Blog URLs had undefined and wouldn't work

### DIFF
--- a/components/ProfileCard.jsx
+++ b/components/ProfileCard.jsx
@@ -22,9 +22,14 @@ const getSocials = (socials, username) => {
   return socials.map((social) => {
     const socialMedia = socialMediaData[social.type];
 
+    if (social.type == "blog" && !social.username.includes("http")) {
+      social.username = `http://${social.username}`;
+    }
     return (
       <SocialLink
-        link={socialMedia.url + social.username}
+        link={[
+          socialMedia.url ? socialMedia.url + social.username : social.username,
+        ]}
         Icon={socialMedia.icon}
         label={username + "'s " + social.type}
         key={social.type}


### PR DESCRIPTION
Blog URLs on the contributing page had undefined (look bottom left of image).
Blog URLs can now be formatted as a proper link containing `http://example.com` or without such as `example.com`
![Screenshot 2021-10-04 at 16 19 16](https://user-images.githubusercontent.com/48966909/135878199-f24f3934-cdbf-4ce2-873d-d6a5f2a88a76.png) 

