### PR TITLE
Fix GTM env var name

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,6 +1,6 @@
 import Document, { Html, Head, Main, NextScript } from "next/document";
 
-const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID;
+const GTM_ID = process.env.GTM_ID;
 
 class MyDocument extends Document {
   render() {


### PR DESCRIPTION
Change Google Tag Manager environment variable name to match the one set in vercel.