### PR TITLE
Contributors page content now stacks to top

### DIFF
--- a/pages/contributors.js
+++ b/pages/contributors.js
@@ -7,7 +7,7 @@ import Contributors from "../components/Contributors";
 export default function Home() {
   // Our page components - layout provides all the wrapping elements
   return (
-    <Layout className="flex flex-col justify-center w-full bg-orange-50">
+    <Layout className="flex flex-col justify-start w-full bg-orange-50">
       <Head>
         <link
           rel="icon"


### PR DESCRIPTION
Flex direction being set as `flex-col`, `justify-center` was centering the content vertically. Setting it to `justify-start` makes the content stack to the top of the page.