### PR TITLE
fix: horizontal overflow

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -39,7 +39,7 @@ class MyDocument extends Document {
           <link rel="apple-touch-icon" href="/icon.png"></link>
           <meta name="theme-color" content="#fff" />
         </Head>
-        <body>
+        <body className="overflow-x-hidden">
           <Main />
           <NextScript />
         </body>


### PR DESCRIPTION
Simple fix for the website overflow that is being caused by the image transform on some screen sizes.

**Before:**
<img width="1788" alt="Screen Shot 2021-10-31 at 18 52 01" src="https://user-images.githubusercontent.com/9519976/139602761-de4e6ca5-eaff-4b88-a0ef-2485f06e277d.png">

**After:**
<img width="1788" alt="Screen Shot 2021-10-31 at 19 04 34" src="https://user-images.githubusercontent.com/9519976/139602764-59e9de43-c322-4e97-839f-a60a69955433.png">


