### PR TITLE
:sparkles: Setup Permanent Redirection from /join to discord server link

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,4 +10,13 @@ module.exports = withPWA({
     skipWaiting: true,
     disable: process.env.NODE_ENV === "development",
   },
+  async redirects() {
+    return [
+      {
+        source: '/join',
+        destination: 'https://discord.com/invite/TcmA2kbJeA',
+        permanent: true,
+      },
+    ]
+  },
 });


### PR DESCRIPTION
I have used the discord link which is already used in the homepage and setup a permanent redirect from /join to the link.

I have only changed the nextjs config file.

```js
const withPWA = require("next-pwa");

module.exports = withPWA({
  images: {
    domains: ["avatars.githubusercontent.com"],
  },
  pwa: {
    dest: "public",
    register: true,
    skipWaiting: true,
    disable: process.env.NODE_ENV === "development",
  },
  //My Change
  async redirects() {
    return [
      {
        source: '/join',
        destination: 'https://discord.com/invite/TcmA2kbJeA',
        permanent: true,
      },
    ]
  },
});
```