### PR TITLE
Improve footer links accessibility

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -5,13 +5,16 @@ const Footer = () => {
       <div className="flex items-center pb-3">
         <div className="flex gap-10">
           <a href="https://github.com/FrancescoXX/4c-site">
-            <FaGithub />
+            <span class="sr-only">Github Repository</span>
+            <FaGithub aria-hidden="true" />
           </a>
           <a href="https://discord.com/invite/TcmA2kbJeA">
-            <FaDiscord />
+            <span class="sr-only">Discord Server</span>
+            <FaDiscord aria-hidden="true" />
           </a>
           <a href="https://twitter.com/4ccommunityhq">
-            <FaTwitter />
+            <span class="sr-only">Twitter</span>
+            <FaTwitter aria-hidden="true" />
           </a>
         </div>
       </div>


### PR DESCRIPTION
This PR adds visually hidden (with Tailwind's ``sr-only`` class) labels to the footer links, so they can be understood in a screen reader context.

Discord link example:

**Before**
![image](https://user-images.githubusercontent.com/9519976/197980326-de447e86-fc83-468b-ab24-487dc9bc94e4.png)

**After**
![image](https://user-images.githubusercontent.com/9519976/197980486-9c13cddb-7077-48ee-bbc5-4007d256d3d6.png)
