### PR TITLE
Bug fix for GetProjects.js

### DIFF
--- a/src/components/GetProjects.js
+++ b/src/components/GetProjects.js
@@ -25,7 +25,7 @@ const GetProjects = () => {
     const arr = []
     for (let i = 0; i < allProjects.projects.length; i++) {
       for (let j = 0; j < selected.length; j++) {
-        if (allProjects.projects[i].stack.includes(selected[j])) {
+        if (allProjects.projects[i].stack?.includes(selected[j])) {
           arr.push(allProjects.projects[i])
         }
       }


### PR DESCRIPTION
Not all projects in "data/projects.json" have stack array included, therefore I used optional chaining so the includes method can work properly.