### PR TITLE
Fixed broken 4c logo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Join our amazing community on Discord and Twitter.
 
 <a href="https://discord.com/invite/cRjhjFRRre"><img src="https://cdn.worldvectorlogo.com/logos/discord-6.svg" title="Discord" alt="Discord Community" width="40"/></a> <a href="https://twitter.com/4ccommunityhq"><img src="https://cdn.worldvectorlogo.com/logos/twitter-6.svg" title="Twitter" alt="Twitter Account" width="40"/></a>
 
-<img src="https://raw.githubusercontent.com/FrancescoXX/4c-site/main/src/assets/banner.jpg" alt="4C logo">
+![4c logo](https://www.4c.rocks/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Flogo.9b920fc5.png&w=64&q=75)
 
 ## :camera: Website overview
 


### PR DESCRIPTION
# Description

I have fixed broken URL of 4c Logo which is now visible under Discord and Twitter icons in Readme.md

## Issue No : 618

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] I have made this from my own
- [x] I have taken help from some online resourses 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

