### PR TITLE
Add some 4C Logo property for prevent the up and down moving issue.

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -38,6 +38,7 @@ const Navbar = () => {
                 <Image
                   width={50}
                   height={50}
+                  id="four-c-logo"
                   className="hover:cursor-pointer"
                   alt="4C Logo"
                   src={logoImage}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -101,4 +101,7 @@ h6 {
   overflow: hidden;
 
 }
-
+#four-c-logo{
+  height: auto;
+  width: 56px;
+}


### PR DESCRIPTION
## Before Change: 
https://user-images.githubusercontent.com/93247057/212470016-898208bd-bf24-4806-9b2e-824715a789a6.mp4

## After Change:
https://user-images.githubusercontent.com/93247057/212470043-552cb451-f407-4e48-bf95-3b4b8485cc19.mp4

Here I added some external CSS properties for the 4c ​​logo image. Although this is not a good solution but it works perfectly.