### PR TITLE
[FIX] : Responsiveness bug fixes for cards

### DIFF
--- a/src/components/BlogCard.js
+++ b/src/components/BlogCard.js
@@ -10,7 +10,7 @@ const BlogCard = () => {
       {blogs.map((blog, index) => (
         <div
           key={index}
-          className="hov-bg-theme m-5 h-[450px] w-[330px] rounded-xl bg-[#f1f5f9] p-5 text-black shadow-md transition-all ease-out hover:-translate-y-1 xl:w-[380px]"
+          className="hov-bg-theme m-5 h-[480px] w-[330px] rounded-xl bg-[#f1f5f9] p-5 text-black shadow-md transition-all ease-out hover:-translate-y-1 xl:w-[380px]"
         >
           <div className="flex justify-between text-2xl">
             <a href={blog.twitter} target="_blank" rel="noreferrer">

--- a/src/components/GetActivities.js
+++ b/src/components/GetActivities.js
@@ -16,8 +16,7 @@ const GetActivities = () => (
               <div>
                 <h2 className="title mt-5 text-2xl">{event.name}</h2>
                 <div className="flex justify-between flex-col sm:flex-row items-start sm:items-center w-full">
-                  <p className="text-md text-right text-[14px] text-gray-600">By {event.organizer}</p>
-                  <h6 className="text-sm">{event.date}</h6>
+                  <p className="text-md  text-[14px] text-gray-600 leading-[20px] mt-3">By {event.organizer} <span className="block sm:inline text-sm font-[600] text-black">{event.date}</span> </p>
                 </div>
                 <img src={event?.image} alt={event.name} className='w-full mb-4 rounded-md object-contain my-4' />
 

--- a/src/components/GetActivities.js
+++ b/src/components/GetActivities.js
@@ -15,7 +15,7 @@ const GetActivities = () => (
             <div key={idx} className='hov-bg-theme m-5  h-auto rounded-xl bg-[#f1f5f9] p-5 text-black shadow-md relative transition-all ease-out xl:w-[380px]'>
               <div>
                 <h2 className="title mt-5 text-2xl">{event.name}</h2>
-                <div className="flex justify-between flex-col sm:flex-row items-start sm:items-center w-full">
+                <div className="w-full">
                   <p className="text-md  text-[14px] text-gray-600 leading-[20px] mt-3">By {event.organizer} <span className="block sm:inline text-sm font-[600] text-black">{event.date}</span> </p>
                 </div>
                 <img src={event?.image} alt={event.name} className='w-full mb-4 rounded-md object-contain my-4' />

--- a/yarn.lock
+++ b/yarn.lock
@@ -374,9 +374,14 @@
   "resolved" "https://registry.npmjs.org/@next/font/-/font-13.1.1.tgz"
   "version" "13.1.1"
 
-"@next/swc-win32-x64-msvc@13.1.1":
-  "integrity" "sha512-mVF0/3/5QAc5EGVnb8ll31nNvf3BWpPY4pBb84tk+BfQglWLqc5AC9q1Ht/YMWiEgs8ALNKEQ3GQnbY0bJF2Gg=="
-  "resolved" "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.1.1.tgz"
+"@next/swc-linux-x64-gnu@13.1.1":
+  "integrity" "sha512-nnjuBrbzvqaOJaV+XgT8/+lmXrSCOt1YYZn/irbDb2fR2QprL6Q7WJNgwsZNxiLSfLdv+2RJGGegBx9sLBEzGA=="
+  "resolved" "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.1.1.tgz"
+  "version" "13.1.1"
+
+"@next/swc-linux-x64-musl@13.1.1":
+  "integrity" "sha512-CM9xnAQNIZ8zf/igbIT/i3xWbQZYaF397H+JroF5VMOCUleElaMdQLL5riJml8wUfPoN3dtfn2s4peSr3azz/g=="
+  "resolved" "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.1.1.tgz"
   "version" "13.1.1"
 
 "@nodelib/fs.scandir@2.1.5":


### PR DESCRIPTION
## Description of changes made : 

- Closes #660 
- Fixed blog card overflow height issue. Made the height to `480px`. 
- Activity card overflow issue. 
- We were using `p` and `h6` tag and then also complicatedly using `flex` to keep them aligned. As a result in some screen sizes or when the content size incrreased the cards broke.
- Currently i have used `p` and `span` with appropriate stylings which serves the same purpose, and is better fitted.

## Screenshots :

**Previously :** 
![prev](https://user-images.githubusercontent.com/72851613/215080251-ed392d85-03dd-44f4-a8f5-695ee8a71770.png)

**Current :**
![Current](https://user-images.githubusercontent.com/72851613/215080290-ea805d09-81c1-4a4e-a275-d7bcdf0ff4ac.png)
