### PR TITLE
Typo in docs - Contributing Guidlines Fixed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # ✨ Contributing to this project
 
-First off all, thanks for taking the time to contribute! 🎉👍
+First of all, thanks for taking the time to contribute! 🎉👍
 
 ## 💣 Reporting Bugs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # ✨ Contributing to this project
 
-First off, thanks for taking the time to contribute! 🎉👍
+First off all, thanks for taking the time to contribute! 🎉👍
 
 ## 💣 Reporting Bugs
 


### PR DESCRIPTION
before: "First of ..."
after: "First of all, ..."
closes #674 