### PR TITLE
fix(Back To Top Button): Solves back to top button overlapping footer icons in mobile-devices

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -3,7 +3,7 @@ import { FaDiscord, FaGithub, FaLinkedin, FaTwitter } from "react-icons/fa"
 
 function Footer() {
   return (
-    <footer className="md:max-md flex flex-col items-center gap-4 bg-[#0d1117] p-4 py-8 text-center text-white/80">
+    <footer className="md:max-md flex flex-col items-center gap-4 bg-[#0d1117] p-4 py-8 text-center text-white/80 footer">
       <div className="flex items-center">
         <div className="flex gap-10">
           <a

--- a/src/components/GoToTop.js
+++ b/src/components/GoToTop.js
@@ -19,6 +19,20 @@ const GoToTop = () => {
     } else {
       setIsVisible(false)
     }
+
+    const footer = document.querySelector(".footer")
+    const backToTopButton = document.querySelector(".backToTopButton")
+    const mediaQuery = window.matchMedia("(max-width: 400px)")
+    const footerIsVisible = footer.getBoundingClientRect().top <= window.innerHeight
+
+    if (mediaQuery.matches) {
+      if (footerIsVisible) {
+        backToTopButton.style.bottom = `${footer.offsetHeight}px`
+        backToTopButton.style.transition = "0.5s"
+      } else {
+        backToTopButton.style.bottom = "48px"
+      }
+    }
   }
 
   useEffect(() => {
@@ -34,7 +48,7 @@ const GoToTop = () => {
       onKeyDown={goToBtn}
       role="button"
       tabIndex={0}
-      className={`fixed bg-gradient-to-b from-green-400 to-blue-600 animate-bounce cursor-pointer  rounded-full p-3 right-12 bottom-12 ${!isVisible ? "hidden" : ""}`}
+      className={`backToTopButton fixed bg-gradient-to-b from-green-400 to-blue-600 animate-bounce cursor-pointer  rounded-full p-3 right-12 bottom-12 ${!isVisible ? "hidden" : "backToTop"}`}
     >
       {isVisible && (
         <div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -36,6 +36,7 @@ h6 {
   color: #fff;
 }
 
+
 @media (min-width: 768px) {
   .text-theme {
     color: #fff;
@@ -45,6 +46,12 @@ h6 {
 @media (min-width: 1024px) {
   .hamburger {
     display: none;
+  }
+}
+
+@media (max-width: 430px){
+  .backToTop{
+    right: 20px;
   }
 }
 
@@ -61,6 +68,10 @@ h6 {
   .main-description {
     text-align: justify;
     font-size: 0.9375rem;
+  }
+
+  .backToTop{
+    right: 10px;
   }
 }
 


### PR DESCRIPTION
Fixes issue: #700 

- Now when the width of the screen is less than 400px, the back-to-top button fixes its position whenever the footer is visible (i.e, in the scope of the current window), such that it does not overlap the footer icons. (Please refer to the image below for reference)
- Added some media queries to fix the position of the button from the right, to suit mobile-devices

*Before:*
![image](https://user-images.githubusercontent.com/71211731/223689463-14c8ff5e-08b0-4cff-9280-e0c7d4a61748.png)

*After:*
![image](https://user-images.githubusercontent.com/71211731/223689706-8c853d7a-4f46-4ea0-8f41-3bd781b17f32.png)

*Demo Video:*

https://user-images.githubusercontent.com/71211731/223689873-9b0a7358-8ed4-4e47-ba9d-3e3c06da770e.mp4

Please let me know if you want me to make any further changes or in case of any feedback, thanks! 