### PR TITLE
fix(project-link-centered): centered links in the project card

### DIFF
--- a/src/components/GetProjects.js
+++ b/src/components/GetProjects.js
@@ -132,7 +132,7 @@ const GetProjects = () => {
                           </p>
                         </div>
                       </div>
-                      <div className="bg-red my-[10px] mt-auto flex h-10 w-full items-center self-end">
+                      <div className="bg-red my-[10px] mt-auto flex h-10 w-full items-center self-end justify-evenly pl-2.5">
                         <a
                           className={
                             project.live_link === ""


### PR DESCRIPTION
Centered the links in the project cards

Before:
![4C-Project-card-centering-defect](https://user-images.githubusercontent.com/83387409/228317107-8c121455-8b01-4559-bc1c-72d6f37e7963.png)

After:
![4C-Project-card-centered](https://user-images.githubusercontent.com/83387409/228317360-d35ade1f-7f08-4013-a9a2-6ee9c64f94c7.png)
