### PR TITLE
[FIX]: Resolved profile bio overflow issue with CSS animation

### DIFF
--- a/src/components/ProfileCard.jsx
+++ b/src/components/ProfileCard.jsx
@@ -71,8 +71,8 @@ const ProfileCard = ({ username, avatar, socials = [], description }) => {
       <span className="mt-3 text-lg text-white">{username}</span>
       {description?.length > 0
         ? (
-          <div className="mt-[.2em] w-[20ch] truncate p-[.4em] text-sm hover:w-[30ch] hover:text-clip">
-            {description}
+          <div className="mt-[.2em] w-[20ch] truncate p-[.4em] text-sm hover:w-[30ch] hover:text-clip wrapper">
+            <p className="target">{description}</p>
           </div>
           )
         : (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -160,3 +160,20 @@ h6 {
   height: auto;
   width: 56px;
 }
+
+.wrapper:hover .target {
+  animation-name: rightToLeft;
+ animation-duration: 5.5s;
+ animation-timing-function: linear;
+ animation-iteration-count: infinite;
+}
+
+
+@keyframes rightToLeft {
+  0% {
+    transform: translateX(200px);
+  }
+  100% {
+    transform: translateX(-500px);
+  }
+}


### PR DESCRIPTION
Issue: #738 

I have added a CSS animation to the profile bio text, which resolves the issue of text overflow on the profile card. By using this animation, the bio text now moves from right to left, allowing the user to read the entire bio without it being cut off.

To implement this solution, I modified the CSS for the bio text and added the animation property. I tested the animation on different browsers and devices to ensure it works correctly and does not impact the performance of the feature.

A screenshot of the profile card with the updated bio display is attached to the Pull Request, which clearly shows the animation in action

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/109217591/232558375-6154a1d7-ff3d-42c2-94c3-57d0e9e6f981.gif)
