### PR TITLE
[Fix]: Issue Templates Syntax Errors

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -29,11 +29,9 @@ body:
       options:
         - label: I agree to follow this project's [Code of Conduct](https://github.com/FrancescoXX/4c-site/blob/main/CODE_OF_CONDUCT.md)
           required: true
-
- - type: markdown
-   attributes:
+  - type: markdown
+    attributes:
       value: |
         ### Call to Action
 
         To Commit on this project you should use `npm run commit`. Do not use `git commit` to avoid unwanted issues.
-

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,4 +1,4 @@
-name: Documentation Report
+name: "Documentation Report"
 description: Suggest improvements for the docs
 title: '[Docs]: '
 labels: ['🚦 status: awaiting triage']

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -31,7 +31,7 @@ body:
           required: true
 
  - type: markdown
-    attributes:
+   attributes:
       value: |
         ### Call to Action
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -40,8 +40,7 @@ body:
       options:
         - label: I agree to follow this project's [Code of Conduct](https://github.com/FrancescoXX/4c-site/blob/main/CODE_OF_CONDUCT.md)
           required: true
-
- - type: markdown
+  - type: markdown
     attributes:
       value: |
         ### Call to Action

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -30,10 +30,9 @@ body:
         - label: I agree to follow this project's [Code of Conduct](https://github.com/FrancescoXX/4c-site/blob/main/CODE_OF_CONDUCT.md)
           required: true
 
- - type: markdown
+  - type: markdown
     attributes:
       value: |
         ### Call to Action
 
         To Commit on this project you should use `npm run commit`. Do not use `git commit` to avoid unwanted issues.
-


### PR DESCRIPTION
This pull request fixes the syntax errors in the issue templates mentioned in Issue #747 . Specifically, the `documentation.yml`, `feature_request.yml`, and `other.yml` templates were not working due to YAML syntax errors.

I have corrected these errors by reviewing the YAML code and identifying and fixing any syntax mistakes. With these fixes, contributors can now use these templates to submit issues in a standardized and consistent format. 