### PR TITLE
fix: image in activities

### DIFF
--- a/src/components/GetActivities.js
+++ b/src/components/GetActivities.js
@@ -30,9 +30,9 @@ const GetActivities = () => (
                 <Image
                   src={event?.image}
                   alt={event.name}
-                  className="w-full mb-4 rounded-md object-contain my-4"
-                  width={20}
-                  height={20}
+                  className="w-full mb-4 rounded-md object-cover my-4"
+                  width={100}
+                  height={100}
                 />
 
                 <div className="flex justify-between text-2xl  bottom-1 w-[100%]">


### PR DESCRIPTION
This PR fixes the image in the activities section that looks bad on the live site

Before:

<img width="1511" alt="Screenshot 2023-11-18 at 13 12 24" src="https://github.com/FrancescoXX/4c-site/assets/96334363/8d6df617-e913-4459-a335-0b5b8e38f30d">


After:

<img width="1511" alt="Screenshot 2023-11-18 at 13 13 02" src="https://github.com/FrancescoXX/4c-site/assets/96334363/c3652cba-80f1-4e63-88e0-aac9dbe54ac5">
